### PR TITLE
Component source URLs now use tags instead of branches

### DIFF
--- a/live/prod/base/terragrunt.hcl
+++ b/live/prod/base/terragrunt.hcl
@@ -13,7 +13,7 @@ include "env" {
 }
 
 terraform {
-  source = "git::git@github.com:cloudership/infra_tf_base.git?ref=master"
+  source = "git::git@github.com:cloudership/infra_tf_base.git?ref=v1.0.0-alpha.001"
 }
 
 prevent_destroy = true

--- a/live/prod/justsayok/terragrunt.hcl
+++ b/live/prod/justsayok/terragrunt.hcl
@@ -17,7 +17,7 @@ dependency "base" {
 }
 
 terraform {
-  source = "git::git@github.com:cloudership/infra_tf_service.git?ref=basic-public-service"
+  source = "git::git@github.com:cloudership/infra_tf_service.git?ref=v1.0.0-alpha.001"
 }
 
 prevent_destroy = true


### PR DESCRIPTION
Forgot to update these in PR #1
